### PR TITLE
Allow YouTube to be embedded

### DIFF
--- a/examples/youtube-html/.htaccess
+++ b/examples/youtube-html/.htaccess
@@ -1,0 +1,1 @@
+Header set Content-Security-Policy "frame-src https://www.youtube-nocookie.com https://www.youtube.com"

--- a/examples/youtube-html/with-youtube-api.html
+++ b/examples/youtube-html/with-youtube-api.html
@@ -60,7 +60,7 @@
                     let player = new YT.Player('yt-container', {
                     height: '390',
                     width: '640',
-                    videoId: 'GU0SV_2tWkU',
+                    videoId: '3kdn2yk6nss',
                     playerVars: {
                         'playsinline': 1
                     },

--- a/examples/youtube-html/with-youtube-embeds.html
+++ b/examples/youtube-html/with-youtube-embeds.html
@@ -48,7 +48,7 @@
                 var iframe = document.createElement('iframe');
                 iframe.setAttribute('width', '560');
                 iframe.setAttribute('height', '315');
-                iframe.setAttribute('src', 'https://www.youtube-nocookie.com/embed/GU0SV_2tWkU');
+                iframe.setAttribute('src', 'https://www.youtube-nocookie.com/embed/3kdn2yk6nss');
                 iframe.setAttribute('title', 'YouTube video player');
                 iframe.setAttribute('frameborder', '0');
                 iframe.setAttribute('allow', 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share');


### PR DESCRIPTION
The Apache-global default `Content-Security-Policy` has `frame-src 'self'`, which forbids loading YouTube in a frame. However, when project correctly use opt-in, they are allowed to override this restriction using `.htaccess`. Show how that's done (and fix the demos).

I also changed the video to something that actually moves in the first second after hitting 'play', to avoid confusion :).

Fixes #32 (though it would still be nice to also document this, not only do it ;) )

Tested in a local Apache httpd