### PR TITLE
fix(csp): Adding *.apache.org to CSP frame-src to fix Matomo opt-out

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+Header set Content-Security-Policy "frame-src *.apache.org 'self'"


### PR DESCRIPTION
On the [this page](https://privacy.apache.org/policies/privacy-policy-public.html) on the Privacy Site, there's supposed to be a means to opt-out from Matomo tracking. This is currently broken due to it being embedded from a different Apache site, which is not allowed by the Privacy Site's CSP. This htaccess file _should_ just poke a hole in the CSP and allow all other Apache sites to be embedded in iframes here.

<img width="830" alt="image" src="https://github.com/apache/privacy-website/assets/812905/79028c55-9293-4c5b-96fc-cb027a37c39a">
