### PR TITLE
configure site link in GitHub

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,3 +1,8 @@
+# https://github.com/apache/infrastructure-asfyaml/blob/main/README.md
+---
+github:
+  description: "Web site for Apache Data Privacy"
+  homepage: https://privacy.apache.org/
 jekyll:
   whoami: main
   target: asf-site


### PR DESCRIPTION
https://privacy.apache.org/ will appear in the "About" block at the top of the page